### PR TITLE
Skin must be added explicitly now

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ and [List](http://docs.webix.com/desktop__list.html). All other widgets with
 How to use
 -----------
 
-- Add the [webix package](https://atmospherejs.com/webix):
+- Add the [webix package](https://atmospherejs.com/webix/webix) and [a skin](https://atmospherejs.com/?q=webix%20skin):
 
     ```sh
-    meteor add webix:webix
+    meteor add webix:webix webix:skin-flat
     ```
 
 - Define data collections as usual:


### PR DESCRIPTION
Now that [skins have been factored out](https://github.com/dandv/meteor-webix/issues/4#issuecomment-96651306), one must be installed explicitly.
