### PR TITLE
Added checks for mongo ObjectIDs, and tests

### DIFF
--- a/codebase/meteor-data.js
+++ b/codebase/meteor-data.js
@@ -106,7 +106,7 @@ webix.proxy.meteor = {
 			});
 		} else if (obj.operation == "insert"){
 			//data added
-			var id = this.collection.insert(this.idHelper.prepareObjData(obj.data, this.collection));
+			var id = this.collection.insert(obj.data);
 			webix.delay(function(){
 				//add an empty string to the id to convert it if it's an ObjectID
 				callback.success("", { newid: id + ''}, -1);
@@ -142,26 +142,8 @@ webix.proxy.meteor = {
 				return false;
 			var currentRecord = collectionMap[id];
 			return (currentRecord && currentRecord._id._str);
-		},
-
-		//if collection uses ObjectIDs, add an ObjectID _id to the obj.data
-		prepareObjData: function(objData, currentCollection){
-			if(this.collectionHasObjectIDs(currentCollection._collection._docs._map))
-				objData._id = new Mongo.Collection.ObjectID();
-			return objData;
-		},
-
-		//for insertions we take the first record in the keys from the map and check if it has an ObjectID
-		collectionHasObjectIDs: function (collectionMap) {
-			if (!collectionMap)
-				return false;
-			var collectionMapKeys = Object.keys(collectionMap);
-			if (!collectionMapKeys || collectionMapKeys.length === 0)
-				return false;
-			var firstKey = collectionMapKeys[0];
-			var firstRecord = collectionMap[firstKey];
-			return (firstRecord && firstRecord._id._str);
 		}
+
 	}
 
 };

--- a/tests/ObjectID.js
+++ b/tests/ObjectID.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var collectionMapWithObjectIDs = {
+    '54aebfacd0269c217710265a':
+    {
+        _id: new Meteor.Collection.ObjectID("54aebfacd0269c217710265a"),
+        someData: "something",
+        moreData: true,
+        someCode: "PT"
+    },
+    '54aebfacd0269c217710265b': {
+        _id: new Meteor.Collection.ObjectID("54aebfacd0269c217710265b"),
+        someData: "europa",
+        moreData: false,
+        someCode: "ES"
+    }
+};
+
+var collectionMapStringIDs = {
+    "KCxbdXLL6GXtCqaQk":
+    {
+        _id: "KCxbdXLL6GXtCqaQk",
+        someData: "something",
+        moreData: true,
+        someCode: "PT"
+    },
+    "LgXXCwt4KsBFAZmGh": {
+        _id: "LgXXCwt4KsBFAZmGh",
+        someData: "europa",
+        moreData: false,
+        someCode: "ES"
+    }
+};
+
+
+Tinytest.add('record has objectID', function (test) {
+    test.isTrue(webix.proxy.meteor.idHelper.recordHasObjectID(collectionMapWithObjectIDs, '54aebfacd0269c217710265a'), 'single record has objectID');
+});
+
+Tinytest.add('collection has objectIDs', function (test) {
+    test.isTrue(webix.proxy.meteor.idHelper.collectionHasObjectIDs(collectionMapWithObjectIDs), 'collection has objectIDs');
+});
+
+Tinytest.add('record has string id', function (test) {
+    test.isFalse(webix.proxy.meteor.idHelper.recordHasObjectID(collectionMapStringIDs, 'KCxbdXLL6GXtCqaQk'), 'single record has string id');
+});
+
+Tinytest.add('collection has string ids', function (test) {
+    test.isFalse(webix.proxy.meteor.idHelper.collectionHasObjectIDs(collectionMapStringIDs), 'collection has String ids');
+});
+
+Tinytest.add('null collection, test for false', function (test) {
+    test.isFalse(webix.proxy.meteor.idHelper.recordHasObjectID(null, 'KCxbdXLL6GXtCqaQk'), 'null collection');
+});
+
+Tinytest.add('empty collection, test for false', function (test) {
+    test.isFalse(webix.proxy.meteor.idHelper.collectionHasObjectIDs({}), 'empty collection');
+});
+
+Tinytest.add('null id, test for false', function (test) {
+    test.isFalse(webix.proxy.meteor.idHelper.recordHasObjectID(collectionMapWithObjectIDs, null), 'empty collection');
+});
+
+Tinytest.add('empty string id, test for false', function (test) {
+    test.isFalse(webix.proxy.meteor.idHelper.recordHasObjectID(collectionMapWithObjectIDs, ''), 'empty collection');
+});
+

--- a/tests/ObjectID.js
+++ b/tests/ObjectID.js
@@ -37,24 +37,12 @@ Tinytest.add('record has objectID', function (test) {
     test.isTrue(webix.proxy.meteor.idHelper.recordHasObjectID(collectionMapWithObjectIDs, '54aebfacd0269c217710265a'), 'single record has objectID');
 });
 
-Tinytest.add('collection has objectIDs', function (test) {
-    test.isTrue(webix.proxy.meteor.idHelper.collectionHasObjectIDs(collectionMapWithObjectIDs), 'collection has objectIDs');
-});
-
 Tinytest.add('record has string id', function (test) {
     test.isFalse(webix.proxy.meteor.idHelper.recordHasObjectID(collectionMapStringIDs, 'KCxbdXLL6GXtCqaQk'), 'single record has string id');
 });
 
-Tinytest.add('collection has string ids', function (test) {
-    test.isFalse(webix.proxy.meteor.idHelper.collectionHasObjectIDs(collectionMapStringIDs), 'collection has String ids');
-});
-
 Tinytest.add('null collection, test for false', function (test) {
     test.isFalse(webix.proxy.meteor.idHelper.recordHasObjectID(null, 'KCxbdXLL6GXtCqaQk'), 'null collection');
-});
-
-Tinytest.add('empty collection, test for false', function (test) {
-    test.isFalse(webix.proxy.meteor.idHelper.collectionHasObjectIDs({}), 'empty collection');
 });
 
 Tinytest.add('null id, test for false', function (test) {


### PR DESCRIPTION
Collections using mongo-style ObjectIDs mean that:

1) calls to save() are silently ignored for updates and deletes
2) we need to add an empty string to the id after an insert

I have written a solution for this. The changes to the current save() function are minimal, the code is in an idHelper object.

There are also five tests in tests/ObjectID.js
